### PR TITLE
feat: make cluster args generic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /pkg/config/testdata/clusters-proxy.json
 /bin/
 /*-toolkit/
+/pkg/config/testdata/clusters-proxy.yaml

--- a/cmd/clusters/clusters.go
+++ b/cmd/clusters/clusters.go
@@ -19,10 +19,11 @@ package clusters
 import (
 	"context"
 	"fmt"
-	"github.com/ghodss/yaml"
 	"os"
 	"os/exec"
 	"time"
+
+	"github.com/ghodss/yaml"
 
 	"github.com/rumstead/gitops-toolkit/pkg/config/v1alpha1"
 	"github.com/rumstead/gitops-toolkit/pkg/gitops/argocd"
@@ -39,13 +40,8 @@ var binaries = map[string]string{"k3d": "", "docker": "", "kubectl": "", "argocd
 func NewClustersCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "clusters",
-		Short: "A brief description of your command",
-		Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+		Short: "Create a set of k3d clusters managed by Argo CD",
+		Long:  ``,
 		PreRunE: func(_ *cobra.Command, _ []string) error {
 			// validate args
 			if _, err := os.Stat(cfgFile); err != nil {
@@ -111,7 +107,6 @@ to quickly create a Cobra application.`,
 				}
 			}
 			// can help if running in an IDE
-			//select {}
 			return nil
 		},
 	}
@@ -129,11 +124,7 @@ func getDefaultClusterConfig() (filePath string) {
 func getOutputDir() (string, error) {
 	dir := os.Getenv("OUTPUT_DIR")
 	if dir == "" {
-		dir, err := os.Getwd()
-		if err != nil {
-			return "", err
-		}
-		return dir, nil
+		return os.TempDir(), nil
 	}
 	return dir, nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,13 +25,8 @@ import (
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "gitops-toolkit",
-	Short: "A brief description of your application",
-	Long: `A longer description that spans multiple lines and likely contains
-examples and usage of using your application. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "Create N of clusters and allow a GitOps engine to manage them",
+	Long:  ``,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	// Run: func(cmd *cobra.Command, args []string) { },

--- a/pkg/kubernetes/k3d/k3d.go
+++ b/pkg/kubernetes/k3d/k3d.go
@@ -81,7 +81,9 @@ func parseClusterCreateArgs(cluster *v1alpha1.RequestCluster) []string {
 	}
 
 	for k, v := range cluster.GetAdditionalArgs() {
-		args = append(args, "--k3s-arg")
+		if k == "k3s-arg" {
+			k = "--k3s-arg"
+		}
 		arg := fmt.Sprintf("%s=%s", k, v)
 		args = append(args, arg)
 	}


### PR DESCRIPTION
```
  additionalArgs:
    k3s-arg: "--tls-san=k3d-admin-serverlb@server:*"
    "--image": "rancher/k3s:v1.26.4-rc1-k3s1"
```